### PR TITLE
EC2: Handle empty `AttributeValues` array

### DIFF
--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -447,7 +447,10 @@ class _Ec2Service(_AwsService):
         attribs = self.conn.describe_account_attributes()
         for attrib in attribs['AccountAttributes']:
             aname = attrib['AttributeName']
-            val = attrib['AttributeValues'][0]['AttributeValue']
+            attribvals = attrib['AttributeValues']
+            if not attribvals:
+                continue
+            val = attribvals[0]['AttributeValue']
             lname = None
             if aname == 'max-elastic-ips':
                 lname = 'Elastic IP addresses (EIPs)'


### PR DESCRIPTION
For more recent regions, the `max-elastic-ips` attribute no longer has a collection of `AttributeValues` so skip over to next attribute.

Example for the recent region `ap-southeast-5`:

```python
[{'AttributeName': 'supported-platforms',
  'AttributeValues': [{'AttributeValue': 'VPC'}]},
 {'AttributeName': 'vpc-max-security-groups-per-interface',
  'AttributeValues': [{'AttributeValue': '5'}]},
 {'AttributeName': 'max-elastic-ips', 'AttributeValues': []},
 {'AttributeName': 'max-instances',
  'AttributeValues': [{'AttributeValue': '20'}]},
 {'AttributeName': 'vpc-max-elastic-ips',
  'AttributeValues': [{'AttributeValue': '5'}]},
 {'AttributeName': 'default-vpc',
  'AttributeValues': [{'AttributeValue': 'vpc-REDACTED'}]}]
```

And for `us-east-1`:

```python
[{'AttributeName': 'supported-platforms',
  'AttributeValues': [{'AttributeValue': 'VPC'}]},
 {'AttributeName': 'vpc-max-security-groups-per-interface',
  'AttributeValues': [{'AttributeValue': '6'}]},
 {'AttributeName': 'max-elastic-ips',
  'AttributeValues': [{'AttributeValue': '1500'}]},
 {'AttributeName': 'max-instances',
  'AttributeValues': [{'AttributeValue': '3000'}]},
 {'AttributeName': 'vpc-max-elastic-ips',
  'AttributeValues': [{'AttributeValue': '3300'}]},
 {'AttributeName': 'default-vpc',
  'AttributeValues': [{'AttributeValue': 'none'}]}]
```

Note difference for `max-elastic-ips`.